### PR TITLE
Update code and allow PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-vendor/*
-.vscode/*
+vendor
+.vscode
+composer.lock

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Signature Gateway PHP Client
 
-[![MIT Licensed](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![MIT Licensed](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
 
 This is Signature Gateway([SiGa](https://github.com/open-eid/SiGa/wiki)) php client.
 

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,15 @@
         "email": "kullar.kert@gmail.com"
 		}
 	],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "require": {
-		"php": "^7.2.5",
-        "guzzlehttp/guzzle": "^7.1@dev"
-	},
+		"php": "^7.2.5 || ^8.0",
+        "ext-ctype": "*",
+        "ext-zip": "*",
+        "ext-dom": "*",
+        "ext-json": "*",
+        "guzzlehttp/guzzle": "^7.1"
+    },
 	"autoload": {
         "psr-4": {
             "SigaClient\\": "src/"

--- a/src/Exception/InvalidSigaParamException.php
+++ b/src/Exception/InvalidSigaParamException.php
@@ -2,15 +2,17 @@
 
 namespace SigaClient\Exception;
 
+use Throwable;
+
 class InvalidSigaParamException extends SigaException
 {
 
     /**
      * @param string $message
      * @param integer $code
-     * @param \Throwable $previous
+     * @param \Throwable|null $previous
      */
-    public function __construct($message, $code = 0, \Throwable $previous = null)
+    public function __construct($message, $code = 0, Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exception/SigaApiResponseException.php
+++ b/src/Exception/SigaApiResponseException.php
@@ -2,15 +2,17 @@
 
 namespace SigaClient\Exception;
 
+use Throwable;
+
 class SigaApiResponseException extends SigaException
 {
 
     /**
      * @param string $message
      * @param integer $code
-     * @param \Throwable $previous
+     * @param \Throwable|null $previous
      */
-    public function __construct($message, $code = 0, \Throwable $previous = null)
+    public function __construct($message, $code = 0, Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exception/SigaException.php
+++ b/src/Exception/SigaException.php
@@ -2,15 +2,18 @@
 
 namespace SigaClient\Exception;
 
-abstract class SigaException extends \RuntimeException
+use RuntimeException;
+use Throwable;
+
+class SigaException extends RuntimeException
 {
-    
+
     /**
      * @param string $message
      * @param integer $code
-     * @param \Throwable $previous
+     * @param \Throwable|null $previous
      */
-    public function __construct($message, $code = 0, \Throwable $previous = null)
+    public function __construct($message, $code = 0, Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Hashcode/Hashcode.php
+++ b/src/Hashcode/Hashcode.php
@@ -46,7 +46,7 @@ class Hashcode
     /**
      * Get hash type name based value
      *
-     * @param string $hash Hash
+     * @param string $type Hash
      *
      * @return string|null Hash type name
      */
@@ -71,7 +71,7 @@ class Hashcode
         if (!in_array($type, array_keys(self::$shaTypes))) {
             return null;
         }
-        
+
         return self::$shaTypes[$type]['bits'] / 8;
     }
 }

--- a/src/Service/SigaGuzzleClient.php
+++ b/src/Service/SigaGuzzleClient.php
@@ -28,7 +28,7 @@ class SigaGuzzleClient extends Guzzle
         $stack->push(Middleware::mapRequest(function (RequestInterface $request) {
             return $request->withHeader('X-Authorization-Timestamp', time());
         }));
-        
+
         $stack->push(Middleware::mapRequest(function (RequestInterface $request) use ($sigaOptions) {
             return $request->withHeader('X-Authorization-ServiceUUID', $sigaOptions['uuid']);
         }));
@@ -38,10 +38,10 @@ class SigaGuzzleClient extends Guzzle
 
             $signature  = $headers['X-Authorization-ServiceUUID'][0].':';
             $signature .= $headers['X-Authorization-Timestamp'][0].':';
-            $signature .= (string)$request->getMethod().':';
-            $signature .= (string)$request->getUri()->getPath().':';
-            $signature .= (string)$request->getBody();
-            
+            $signature .= $request->getMethod() .':';
+            $signature .= $request->getUri()->getPath() .':';
+            $signature .= $request->getBody();
+
             return $request->withHeader('X-Authorization-Signature', hash_hmac('sha256', $signature, $sigaOptions['secret']));
         }));
 


### PR DESCRIPTION
- updated composer.json to allow php ^8.0 and changed minimum-stability to stable
- updated docblocks
- removed abstract from SigaException class to allow throwing it directly in HashcodeContainer::saveContainerWithFiles()
- added composer.lock to .gitignore
- fixed link to LICENSE in README.md
- removed redundant type casts in SigaGuzzleClient::__construct()
- removed unused import in SigaClient.php
- replaced fully qualified name usage with import